### PR TITLE
fixes issues with TR prefab changes in Racket7 release

### DIFF
--- a/digitama/message.rkt
+++ b/digitama/message.rkt
@@ -4,7 +4,9 @@
 (provide (rename-out [object-name struct-name]))
 
 (require typed/db/base)
-(require "misc.rkt")
+(require "misc.rkt"
+         prefab-predicate-compat
+         (for-syntax racket/syntax))
 
 (require/typed racket/base
                [object-name (-> (U Struct-TypeTop exn) Symbol)])
@@ -14,8 +16,10 @@
 (define-syntax (struct: stx)
   (syntax-case stx [:]
     [(_ id : ID rest ...)
-     #'(begin (struct id rest ... #:prefab)
-              (define-type ID id))]))
+     #`(begin (struct id rest ... #:prefab)
+              (define-type ID id)
+              (define-backwards-compatible-flat-prefab-predicate
+                #,(format-id #'id "~a?" (syntax-e #'ID)) id))]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (define rest->message : (-> (U String (Pairof String (Listof Any))) String)

--- a/info.rkt
+++ b/info.rkt
@@ -5,7 +5,8 @@
 (define pkg-authors '(wargrey))
 
 (define version "1.0")
-(define deps '("base" "db-lib" "typed-racket-lib" "typed-racket-more"))
+(define deps '("base" "db-lib" "typed-racket-lib" "typed-racket-more"
+                      "prefab-predicate-compat"))
 (define build-deps '("scribble-lib" "racket-doc"))
 (define test-omit-paths 'all)
 

--- a/message.rkt
+++ b/message.rkt
@@ -27,8 +27,10 @@
 
 (define schema-message-replace-urgent : (-> Schema-Message Any Schema-Message)
   (lambda [message urgent]
-    (cond [(msg:schema:table? message) (struct-copy msg:schema:table message [urgent #:parent msg:schema urgent])]
-          [(msg:schema:error? message) (struct-copy msg:schema:error message [urgent #:parent msg:schema urgent])]
+    (cond [(Schema-Table-Message? message)
+           (struct-copy msg:schema:table message [urgent #:parent msg:schema urgent])]
+          [(Schema-Error-Message? message)
+           (struct-copy msg:schema:error message [urgent #:parent msg:schema urgent])]
           [else (struct-copy msg:schema message [urgent urgent])])))
 
 (define schema-log-message : (-> Schema-Message [#:logger Logger] [#:alter-topic (U Symbol Struct-TypeTop False)] Void)


### PR DESCRIPTION
We recently fixed how Typed Racket handles prefab structures (see the [RFC](https://github.com/racket/typed-racket/blob/master/rfcs/text/0001-prefab-structs.md) for more details). This fix unfortunately breaks a few places in this package.

This pull request fixes those issues in a way that is both backwards and forwards compatible. In other words, it should be safe to merge this PR and people using this package on current/previous versions of Racket will notice no difference, and when Racket 7 is released the package will continue to work.